### PR TITLE
refactor: blog posts section on home page

### DIFF
--- a/src/components/pages/home/blog-posts/blog-posts.tsx
+++ b/src/components/pages/home/blog-posts/blog-posts.tsx
@@ -4,8 +4,8 @@ import Container from '@/components/shared/container';
 
 import { getAllPosts } from '@/lib/blog-api';
 
-import { PostPreview } from '../../blog/post-preview';
 import BlogHeader from './blog-header';
+import PostItem from './post-item';
 
 export default function BlogPosts() {
   const locale = useLocale(); // Get the current locale from next-intl
@@ -14,9 +14,9 @@ export default function BlogPosts() {
   return (
     <Container>
       <BlogHeader />
-      <div className="grid-col-1 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <div className="grid-col-1 mb-28 grid gap-x-4 gap-y-10 md:grid-cols-2 lg:grid-cols-3">
         {allPosts.map((post) => (
-          <PostPreview
+          <PostItem
             key={post.slug}
             title={post.title}
             coverImage={post.coverImage}

--- a/src/components/pages/home/blog-posts/post-item/index.ts
+++ b/src/components/pages/home/blog-posts/post-item/index.ts
@@ -1,0 +1,3 @@
+import PostItem from './post-item';
+
+export default PostItem;

--- a/src/components/pages/home/blog-posts/post-item/post-item.tsx
+++ b/src/components/pages/home/blog-posts/post-item/post-item.tsx
@@ -1,0 +1,43 @@
+import { Route } from 'next';
+import Image from 'next/image';
+
+import { Link } from '@/i18n/routing';
+import cn from 'classnames';
+
+type Props = {
+  title: string;
+  coverImage: string;
+  excerpt: string;
+  slug: string;
+};
+
+export default function PostItem({ title, coverImage, excerpt, slug }: Props) {
+  return (
+    <div>
+      <div className="mb-5">
+        <Link href={`/blog/${slug}`} aria-label={title}>
+          <Image
+            src={coverImage}
+            alt={`Image for ${title}`}
+            className={cn(
+              'aspect-video w-full rounded-xl border border-gray-98 object-cover object-center',
+              {
+                'transition-shadow duration-200 hover:shadow-lg': slug,
+              },
+            )}
+            width={1300}
+            height={630}
+          />
+        </Link>
+      </div>
+      <h3 className="mb-3 line-clamp-3 text-24 font-medium leading-snug tracking-tight text-gray-20">
+        <Link href={`/blog/${slug}` as Route} className="hover:underline">
+          {title}
+        </Link>
+      </h3>
+      <p className="mb-4 line-clamp-4 text-20 leading-snug tracking-tight text-gray-40">
+        {excerpt}
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
**Description**

1. This pull request brings redesign for Home page in Blog Posts section

Additional changes:
- add margin between BlogPosts section and Footer
- specify an aspect ratio + center position for all blog-post covers (this helps maintain a consistent image size)
- font size adjustments
- grid gaps changes
- line clamp for long description and headers

**Screenshots**

<details>
<summary>Before</summary>
<img width="" alt="" src="https://github.com/user-attachments/assets/8e38c339-479e-4f5f-992c-a05acedec863">

</details>

<details>
<summary>After</summary>
<img width="" alt="" src="https://github.com/user-attachments/assets/7bf1e02c-92a1-48e7-b661-193d55e6d452">
</details>

<!--
**TODO**
-->

<!--
Add any tasks that have to be done in the future.
An example:
- [ ] Add animations for items while they are being changed in **Products**
- [ ] Add stripes on background for **Awards**
If this pull request does not have any tasks left, set N/A as a value for it.
-->

<!--
Tag any related issues or tasks in Notion.
Some examples:
1. Resolves #1.
2. Closes #1.
3. Fixes #1.
4. Closes the task [Update README](https://www.notion.so/) in Notion.
You can read more about linking a pull request to an issue here — https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
If this pull request does not contain any references, set N/A as a value for it.
-->
